### PR TITLE
Replace IAM User creds with IAM Role

### DIFF
--- a/.github/workflows/cortex_m_virtual_hardware.yml
+++ b/.github/workflows/cortex_m_virtual_hardware.yml
@@ -1,6 +1,4 @@
 # The repository needs to provide the following secrets
-# - AWS_ACCESS_KEY_ID           The id of the access key.
-# - AWS_SECRET_ACCESS_KEY       The access key secret.
 # - AWS_DEFAULT_REGION          The data center region to be used.
 # - AWS_S3_BUCKET_NAME          The name of the S3 storage bucket to be used for data exchange.
 # - AWS_IAM_PROFILE             The IAM profile to be used.
@@ -15,34 +13,41 @@ on:
   workflow_dispatch:
 
 env:
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
   AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
   AWS_IAM_PROFILE: ${{ secrets.AWS_IAM_PROFILE }}
   AWS_SECURITY_GROUP_ID: ${{ secrets.AWS_SECURITY_GROUP_ID }}
   AWS_SUBNET_ID: ${{ secrets.AWS_SUBNET_ID }}
-  
+
 jobs:
   cortex_m_generic:
     runs-on: ubuntu-latest
-      
+    permissions:
+      id-token: write
+      contents: read
+
     name: Cortex-M7 Virtual Hardware Target
     steps:
     - name: Checkout
-      uses: actions/checkout@v2    
-  
+      uses: actions/checkout@v2
+
     - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
         python-version: '3.10'
-        
+
+    - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::720528183931:role/Proj-vht-assume-role
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
     - name: Install AVH Client for Python
       run: |
         pip install git+https://github.com/ARM-software/avhclient.git@v0.1
 
     - name: Prepare test suite
-      env: 
+      env:
         MQTT_BROKER_ENDPOINT: ${{ secrets.MQTT_BROKER_ENDPOINT }}
         IOT_THING_NAME: ${{ secrets.IOT_THING_NAME }}
         CLIENT_CERTIFICATE_PEM: ${{ secrets.CLIENT_CERTIFICATE_PEM }}


### PR DESCRIPTION
This avoids rotation of the IAM User creds.

The secrets `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` can be deleted after this PR is merged.